### PR TITLE
Update BlockBitDrawers.java

### DIFF
--- a/src/main/java/mods/belgabor/bitdrawers/block/BlockBitDrawers.java
+++ b/src/main/java/mods/belgabor/bitdrawers/block/BlockBitDrawers.java
@@ -104,6 +104,11 @@ public class BlockBitDrawers extends BlockDrawers implements INetworked
         else
             return 2;
     }
+    
+    @Override
+    protected boolean overridesShouldSideBeRendered () {
+        return false;
+    }
 
     @Override
     public IBlockState onBlockPlaced (World world, BlockPos pos, EnumFacing facing, float hitX, float hitY, float hitZ, int meta, EntityLivingBase placer) {


### PR DESCRIPTION
Don't use BlockDrawer's default implementation of shouldSideBeRendered, because it depends on the BLOCK property type.